### PR TITLE
PHP8 Compatibility - Handle null attribute values

### DIFF
--- a/Model/SetMetaRobots.php
+++ b/Model/SetMetaRobots.php
@@ -51,7 +51,7 @@ class SetMetaRobots implements SetMetaRobotsInterface
      */
     protected function attributeIsFlaggedInEntity(DataObject $entity, $attributeCode): bool
     {
-        return $entity->getData($attributeCode);
+        return $entity->getData($attributeCode) ?? false;
     }
 
     /**


### PR DESCRIPTION
I noticed that this extension does not currently work correctly with PHP8. If the attribute in question is null (Which it will be by default), PHP will throw a type error, because `attributeIsFlaggedInEntity` will try to return null, even though it specifies that it must return a boolean. 